### PR TITLE
feat(pressure): 支持触摸笔压力感知的拖拽交互

### DIFF
--- a/apps/demo/src/main.ts
+++ b/apps/demo/src/main.ts
@@ -1,6 +1,8 @@
 import './style.css'
 import {
   Drag,
+  DragOperationType,
+  Finger,
   Mixin,
   MixinType,
   defaultSetPose,
@@ -55,6 +57,20 @@ appElement.innerHTML = `
                 </div>
             </div>
         </section>
+        <section class="panel">
+            <div>
+                <h2>压力敏感拖拽演示</h2>
+                <p>使用触摸笔或 Force Touch 触摸板拖拽，观察压力对视觉效果的影响。</p>
+            </div>
+            <div class="drag-zone">
+                <div class="drag-container">
+                    <div class="draggable-item pressure-item" id="pressure-item">
+                        <span class="pressure-label">压力敏感拖拽</span>
+                        <span class="pressure-value" id="pressure-value">0.50</span>
+                    </div>
+                </div>
+            </div>
+        </section>
     </div>
 `
 
@@ -63,11 +79,13 @@ const item2 = document.getElementById('item2') as HTMLElement
 const item3 = document.getElementById('item3') as HTMLElement
 const joystick1 = document.getElementById('joystick1') as HTMLElement
 const joystick2 = document.getElementById('joystick2') as HTMLElement
+const pressureItem = document.getElementById('pressure-item') as HTMLElement
 
 for (const [element, top] of [
   [item1, 20],
   [item2, 120],
-  [item3, 220]
+  [item3, 220],
+  [pressureItem, 20]
 ] as const) {
   element.style.position = 'absolute'
   element.style.left = '24px'
@@ -117,4 +135,12 @@ new Drag(joystick1, {
 new Drag(joystick2, {
   setPose: limit75,
   setPoseOnEnd: joystickGoBack
+})
+
+const pressureDrag = new Drag(pressureItem)
+const pressureValue = document.getElementById('pressure-value') as HTMLElement
+pressureDrag.addEventListener(DragOperationType.Move, (fingers: Finger[]) => {
+  const pressure = fingers[0]?.getLastOperation()?.pressure ?? 0.5
+  pressureItem.style.setProperty('--pressure', String(pressure))
+  pressureValue.textContent = pressure.toFixed(2)
 })

--- a/apps/demo/src/style.css
+++ b/apps/demo/src/style.css
@@ -107,3 +107,25 @@ body {
     background: #818cf8;
     cursor: grab;
 }
+
+.pressure-item {
+    --pressure: 0.5;
+
+    opacity: calc(0.4 + var(--pressure) * 0.6);
+    transform: scale(calc(0.5 + var(--pressure)));
+    box-shadow: 0 calc(4px * var(--pressure)) calc(12px * var(--pressure)) rgba(99, 102, 241, calc(0.3 * var(--pressure)));
+    transition: opacity 0.1s ease-out, transform 0.1s ease-out, box-shadow 0.1s ease-out;
+}
+
+.pressure-item .pressure-label {
+    display: block;
+    margin-bottom: 4px;
+}
+
+.pressure-item .pressure-value {
+    display: block;
+    font-size: 24px;
+    font-weight: 700;
+    color: #818cf8;
+    font-variant-numeric: tabular-nums;
+}

--- a/packages/multi-drag-core/src/__tests__/controller.test.ts
+++ b/packages/multi-drag-core/src/__tests__/controller.test.ts
@@ -78,6 +78,36 @@ describe('GestureController', () => {
     expect(snapshot.pose.scale).not.toBe(1)
   })
 
+  it('propagates pointer pressure to snapshots', () => {
+    const controller = new GestureController({ features: { drag: true } })
+
+    const startSnapshot = controller.process(
+      {
+        pointerId: 1,
+        phase: PointerPhase.Start,
+        point: { x: 10, y: 10 },
+        timestamp: 0,
+        pressure: 0.25
+      },
+      { pose: createPose() }
+    )
+
+    expect(startSnapshot.activePointers[0].pressure).toBe(0.25)
+
+    const moveSnapshot = controller.process(
+      {
+        pointerId: 1,
+        phase: PointerPhase.Move,
+        point: { x: 20, y: 20 },
+        timestamp: 16,
+        pressure: 0.75
+      },
+      { pose: createPose() }
+    )
+
+    expect(moveSnapshot.activePointers[0].pressure).toBe(0.75)
+  })
+
   it('keeps the two-finger pose when one pointer lifts and continues from it', () => {
     const controller = new GestureController({ features: { drag: true } })
     const pose = createPose()

--- a/packages/multi-drag-core/src/controller.ts
+++ b/packages/multi-drag-core/src/controller.ts
@@ -4,13 +4,13 @@ import {
   computeScaleDelta
 } from './geometry'
 import {
-  GesturePhase,
-  PointerPhase,
   type GestureComputeContext,
   type GestureControllerOptions,
+  GesturePhase,
   type GesturePointerSnapshot,
   type GestureSnapshot,
   type NormalizedPointerInput,
+  PointerPhase,
   type Pose
 } from './types'
 
@@ -96,7 +96,8 @@ export class GestureController {
       startPoint: { ...input.point },
       currentPoint: { ...input.point },
       startTimestamp: input.timestamp,
-      currentTimestamp: input.timestamp
+      currentTimestamp: input.timestamp,
+      pressure: input.pressure
     })
   }
 
@@ -107,6 +108,7 @@ export class GestureController {
   ) {
     pointer.currentPoint = { ...input.point }
     pointer.currentTimestamp = input.timestamp
+    pointer.pressure = input.pressure
 
     if (!this.initialPose) {
       this.initialPose = clonePose(context.pose)
@@ -201,7 +203,8 @@ export class GestureController {
         startPoint: { ...pointer.startPoint },
         currentPoint: { ...pointer.currentPoint },
         startTimestamp: pointer.startTimestamp,
-        currentTimestamp: pointer.currentTimestamp
+        currentTimestamp: pointer.currentTimestamp,
+        pressure: pointer.pressure
       }))
     }
   }

--- a/packages/multi-drag-core/src/types.ts
+++ b/packages/multi-drag-core/src/types.ts
@@ -36,6 +36,7 @@ export interface NormalizedPointerInput {
   point: Point
   phase: PointerPhase
   timestamp: number
+  pressure?: number
   pointerType?: string
   isPrimary?: boolean
 }
@@ -52,6 +53,7 @@ export interface GesturePointerSnapshot {
   currentPoint: Point
   startTimestamp: number
   currentTimestamp: number
+  pressure?: number
 }
 
 export interface GestureComputeContext {

--- a/packages/multi-drag/src/__tests__/pressure.test.ts
+++ b/packages/multi-drag/src/__tests__/pressure.test.ts
@@ -42,7 +42,9 @@ describe('pressure support', () => {
 
   it('normalizes mouse pressure only while buttons are active', () => {
     expect(normalizePressure(createEvent('mouse', { buttons: 1 }))).toBe(0.5)
-    expect(normalizePressure(createEvent('mouse', { buttons: 0 }))).toBeUndefined()
+    expect(
+      normalizePressure(createEvent('mouse', { buttons: 0 }))
+    ).toBeUndefined()
   })
 
   it('normalizes touch pressure and Safari webkitForce', () => {

--- a/packages/multi-drag/src/__tests__/pressure.test.ts
+++ b/packages/multi-drag/src/__tests__/pressure.test.ts
@@ -1,0 +1,92 @@
+import { PointerPhase } from '@system-ui-js/multi-drag-core'
+import {
+  normalizePointerEvent,
+  normalizePressure
+} from '../dom/normalize-pointer-event'
+import { Finger, FingerOperationType } from '../drag/finger'
+import { createPointerEvent } from './utils'
+
+function createEvent(
+  pointerType: string,
+  fields: PointerEventInit & { webkitForce?: number } = {}
+) {
+  const { webkitForce, ...init } = fields
+  const event = createPointerEvent('pointermove', {
+    pointerType,
+    ...init
+  })
+
+  if ('pressure' in init) {
+    Object.defineProperty(event, 'pressure', {
+      configurable: true,
+      value: init.pressure
+    })
+  }
+
+  if (typeof webkitForce === 'number') {
+    Object.defineProperty(event, 'webkitForce', {
+      configurable: true,
+      value: webkitForce
+    })
+  }
+
+  return event
+}
+
+describe('pressure support', () => {
+  it('normalizes pen pressure with clamping', () => {
+    expect(normalizePressure(createEvent('pen', { pressure: 0.75 }))).toBe(0.75)
+    expect(normalizePressure(createEvent('pen', { pressure: 2 }))).toBe(1)
+    expect(normalizePressure(createEvent('pen', { pressure: -0.25 }))).toBe(0)
+  })
+
+  it('normalizes mouse pressure only while buttons are active', () => {
+    expect(normalizePressure(createEvent('mouse', { buttons: 1 }))).toBe(0.5)
+    expect(normalizePressure(createEvent('mouse', { buttons: 0 }))).toBeUndefined()
+  })
+
+  it('normalizes touch pressure and Safari webkitForce', () => {
+    expect(normalizePressure(createEvent('touch', { pressure: 0.4 }))).toBe(0.4)
+    expect(normalizePressure(createEvent('touch', { webkitForce: 0.6 }))).toBe(
+      0.6
+    )
+  })
+
+  it('returns pressure from normalized pointer input', () => {
+    const event = createEvent('pen', {
+      clientX: 10,
+      clientY: 20,
+      pointerId: 3,
+      pressure: 0.8
+    })
+
+    expect(normalizePointerEvent(event, PointerPhase.Move)).toMatchObject({
+      pointerId: 3,
+      point: { x: 10, y: 20 },
+      phase: PointerPhase.Move,
+      pressure: 0.8,
+      pointerType: 'pen'
+    })
+  })
+
+  it('records pressure in finger path items', () => {
+    const startEvent = createEvent('pen', {
+      clientX: 0,
+      clientY: 0,
+      pointerId: 1,
+      pressure: 0.2
+    })
+    const moveEvent = createEvent('pen', {
+      clientX: 5,
+      clientY: 8,
+      pointerId: 1,
+      pressure: 0.7
+    })
+
+    const finger = new Finger(startEvent)
+    const moveItem = finger.record(FingerOperationType.Move, moveEvent)
+
+    expect(finger.getPath()[0].pressure).toBe(0.2)
+    expect(moveItem.pressure).toBe(0.7)
+  })
+})

--- a/packages/multi-drag/src/dom/normalize-pointer-event.ts
+++ b/packages/multi-drag/src/dom/normalize-pointer-event.ts
@@ -1,7 +1,38 @@
-import {
+import type {
   NormalizedPointerInput,
   PointerPhase
 } from '@system-ui-js/multi-drag-core'
+
+interface PointerEventWithWebkitForce extends PointerEvent {
+  webkitForce?: number
+}
+
+function clampPressure(pressure: number) {
+  return Math.min(Math.max(pressure, 0), 1)
+}
+
+function getEventPressure(event: PointerEvent) {
+  const pressure = event.pressure
+  if (typeof pressure === 'number') {
+    return pressure
+  }
+
+  const webkitForce = (event as PointerEventWithWebkitForce).webkitForce
+  return typeof webkitForce === 'number' ? webkitForce : undefined
+}
+
+export function normalizePressure(event: PointerEvent): number | undefined {
+  if (event.pointerType === 'mouse') {
+    const webkitForce = (event as PointerEventWithWebkitForce).webkitForce
+    if (typeof webkitForce === 'number' && webkitForce > 0) {
+      return clampPressure(webkitForce)
+    }
+    return event.buttons > 0 ? 0.5 : undefined
+  }
+
+  const pressure = getEventPressure(event)
+  return typeof pressure === 'number' ? clampPressure(pressure) : undefined
+}
 
 export function normalizePointerEvent(
   event: PointerEvent,
@@ -15,6 +46,7 @@ export function normalizePointerEvent(
     },
     phase,
     timestamp: event.timeStamp,
+    pressure: normalizePressure(event),
     pointerType: event.pointerType,
     isPrimary: event.isPrimary
   }

--- a/packages/multi-drag/src/drag/finger.ts
+++ b/packages/multi-drag/src/drag/finger.ts
@@ -1,4 +1,5 @@
 import type { Point } from '@system-ui-js/multi-drag-core'
+import { normalizePressure } from '../dom/normalize-pointer-event'
 
 export enum FingerOperationType {
   Start = 'start',
@@ -10,6 +11,7 @@ export interface FingerPathItem {
   point: Point
   timestamp: number
   type: FingerOperationType
+  pressure?: number
   event?: PointerEvent
 }
 
@@ -40,6 +42,7 @@ export class Finger {
       point: { x: event.clientX, y: event.clientY },
       timestamp: event.timeStamp,
       type,
+      pressure: normalizePressure(event),
       event
     }
     this.path.push(item)


### PR DESCRIPTION
## Summary
- 添加 normalizedPointerInput 中 pressure 字段的支持
- 在 GesturePointerSnapshot 中传播 pressure 信息
- 新增 normalizePressure 函数，支持标准 PointerEvent.pressure 和 webkitForce（Apple 设备）
- 演示应用添加压力敏感拖拽交互，通过 CSS 变量动态响应触摸压力

## Testing
- npm run lint
- npm run test